### PR TITLE
Feature/#10 youtube modal layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.2.0",
     "tailwindcss": "3.3.5",
     "zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.0.0)
       react-router-dom:
         specifier: ^7.2.0
         version: 7.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1400,6 +1403,11 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3148,6 +3156,10 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-icons@5.5.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   react-is@16.13.1: {}
 

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -3,7 +3,7 @@ import Nav from './Nav';
 
 export default function Header() {
   return (
-    <header className='flexCenter !justify-between py-[20px] px-[2%]'>
+    <header className='flexCenter !justify-between bg-bg-primary py-[20px] px-[2%] w-full fixed top-0 left-0'>
       <h1 className='font-gugi text-3xl'>
         <Link to='/'>서울핫플</Link>
       </h1>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -5,7 +5,7 @@ export default function Layout() {
   return (
     <div id='layout' className='bg-bg-primary min-h-[100dvh]'>
       <Header />
-      <div className='p-6'>
+      <div className='px-6 pt-[130px] '>
         <Outlet />
       </div>
     </div>

--- a/src/components/modal/detail-modal.jsx
+++ b/src/components/modal/detail-modal.jsx
@@ -4,6 +4,7 @@ import { FaYoutube } from 'react-icons/fa6';
 import { FaRegBookmark } from 'react-icons/fa6';
 import { FaBookmark } from 'react-icons/fa';
 import { useState } from 'react';
+import { STORE_CONSTANT } from '@/constants/store-constant';
 const STORE_MOCK_DATA = {
   name: '양복점',
   category_name: '음식점',
@@ -13,15 +14,6 @@ const STORE_MOCK_DATA = {
   img_url:
     'https://ugc-images.catchtable.co.kr/catchtable/shopinfo/s2ITBk3Dv9LVsluH7e0DjIw/3619ed3090ef45d0a7e3f3c93e8489db',
 }; //TODO: supabase 데이터 완성되면 지울 예정
-
-const STORE_CONSTANT = {
-  STORE_NAME: 'name',
-  STORE_ADDRESS: 'address_road_name',
-  STORE_CONTACT: 'contact_number',
-  CATEGORY: 'category_name',
-  STORE_PIC: 'img_url',
-  BUSINESS_HOUR: 'open_hours',
-}; //@TODO: 현재 기준 supabase의 data table을 기준으로 가져온 key입니다.
 
 const { STORE_NAME, STORE_ADDRESS, STORE_CONTACT, STORE_PIC, BUSINESS_HOUR, CATEGORY } = STORE_CONSTANT;
 
@@ -33,17 +25,17 @@ const DETAIL_LIST = [
   {
     key: STORE_ADDRESS,
     title: '주소',
-    default: '등록된 주소가 없습니다.',
+    defaultMessage: '등록된 주소가 없습니다.',
   },
   {
     key: STORE_CONTACT,
     title: '전화번호',
-    default: '등록된 전화번호가 없습니다.',
+    defaultMessage: '등록된 전화번호가 없습니다.',
   },
   {
     key: BUSINESS_HOUR,
     title: '영업 시간',
-    default: '업체에 직접 문의해 주세요.',
+    defaultMessage: '업체에 직접 문의해 주세요.',
   },
 ];
 
@@ -60,35 +52,35 @@ export default function DetailModal() {
   };
 
   return (
-    <section className='bg-accent w-[40%] max-w-[650px] min-w-[300px] min-h-[50dvh] max-h-[85dvh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-8 py-10 rounded-lg '>
+    <section className='modal'>
       <p className='h-[80%] md:h-[65%] max-h-[400px] mb-5'>
         <img
           src={STORE_MOCK_DATA[STORE_PIC]}
           alt={STORE_MOCK_DATA[STORE_NAME]}
           className='object-cover w-full h-full rounded-lg'
         />
-        <span className='text-text-light absolute top-2 right-2 text-2xl cursor-pointer '>
+        <span className='text-text-primary absolute top-2 right-2 text-2xl cursor-pointer '>
           <IoCloseOutline />
         </span>
       </p>
 
       <div className='flexCenter !justify-between  mb-[10px]'>
-        <h4 className='font-bold text-2xl sm:text-3xl text-text-light'>{STORE_MOCK_DATA[STORE_NAME]}</h4>
+        <h4 className='font-bold text-2xl sm:text-3xl text-accent-active'>{STORE_MOCK_DATA[STORE_NAME]}</h4>
         <span className='text-2xl cursor-pointer' onClick={addToBookmark}>
-          {isBookMarked ? <FaBookmark className='text-text-light' /> : <FaRegBookmark className='text-text-light' />}
+          {isBookMarked ? <FaBookmark className='text-accent' /> : <FaRegBookmark className='text-accent' />}
         </span>
       </div>
 
-      <dl className='flex flex-wrap mb-[20px] text-text-light'>
+      <dl className='flex flex-wrap mb-[20px] '>
         {DETAIL_LIST.map((list) => (
           <React.Fragment key={list.key}>
             <dt className='w-[30%] sm:w-[20%] m-w-[150px] mb-1'>{list.title}</dt>
-            <dd className='w-[70%] sm:w-[80%]'>{STORE_MOCK_DATA[list.key] ?? list?.default}</dd>
+            <dd className='w-[70%] sm:w-[80%]'>{STORE_MOCK_DATA[list.key] ?? list?.defaultMessage}</dd>
           </React.Fragment>
         ))}
       </dl>
-      <button className='w-full bg-white text-text-primary text-center py-1 rounded-lg'>
-        <FaYoutube className='text-4xl w-full' />
+      <button className='w-full bg-accent text-text-primary text-center py-1 rounded-lg'>
+        <FaYoutube className='text-4xl w-full text-white' />
       </button>
     </section>
   );

--- a/src/components/modal/detail-modal.jsx
+++ b/src/components/modal/detail-modal.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { IoCloseOutline } from 'react-icons/io5';
+import { FaYoutube } from 'react-icons/fa6';
+import { FaRegBookmark } from 'react-icons/fa6';
+import { FaBookmark } from 'react-icons/fa';
+import { useState } from 'react';
+const STORE_MOCK_DATA = {
+  name: '양복점',
+  category_name: '음식점',
+  address_road_name: '서울 용산구 새창로 209 5동 지하층 3호',
+  contact_number: '02-1234-5678',
+  open_hours: '10:00 ~  22:00',
+  img_url:
+    'https://ugc-images.catchtable.co.kr/catchtable/shopinfo/s2ITBk3Dv9LVsluH7e0DjIw/3619ed3090ef45d0a7e3f3c93e8489db',
+}; //TODO: supabase 데이터 완성되면 지울 예정
+
+const STORE_CONSTANT = {
+  STORE_NAME: 'name',
+  STORE_ADDRESS: 'address_road_name',
+  STORE_CONTACT: 'contact_number',
+  CATEGORY: 'category_name',
+  STORE_PIC: 'img_url',
+  BUSINESS_HOUR: 'open_hours',
+}; //@TODO: 현재 기준 supabase의 data table을 기준으로 가져온 key입니다.
+
+const { STORE_NAME, STORE_ADDRESS, STORE_CONTACT, STORE_PIC, BUSINESS_HOUR, CATEGORY } = STORE_CONSTANT;
+
+const DETAIL_LIST = [
+  {
+    key: CATEGORY,
+    title: '분류',
+  },
+  {
+    key: STORE_ADDRESS,
+    title: '주소',
+    default: '등록된 주소가 없습니다.',
+  },
+  {
+    key: STORE_CONTACT,
+    title: '전화번호',
+    default: '등록된 전화번호가 없습니다.',
+  },
+  {
+    key: BUSINESS_HOUR,
+    title: '영업 시간',
+    default: '업체에 직접 문의해 주세요.',
+  },
+];
+
+//TODO: props로 리스트에서 타겟팅한 가게의 id 받아오기 , 혹시 모달 밖에 클릭했을 때 닫히는 이벤트 구현한다면 onClose 상태도 같이 받아오기 & 이벤트 버블링 막아서 처리하기
+export default function DetailModal() {
+  //TODO: user정보 받아와서 bookmark 여부 확인 후 초기값으로 넣어주기
+  const [isBookMarked, setIsBookMarked] = useState(false);
+
+  const addToBookmark = () => {
+    setIsBookMarked(!isBookMarked);
+    alert(`북마크${isBookMarked ? '에서 삭제' : '에 추가'}되었습니다.`);
+    //TODO: alert 추후에 sweetAlert를 쓰든 바꾸기
+    //TODO: user의 bookmark 상태 바꾸기 (->post api연결)
+  };
+
+  return (
+    <section className='bg-accent w-[40%] max-w-[650px] min-w-[300px] min-h-[50dvh] max-h-[85dvh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-8 py-10 rounded-lg '>
+      <p className='h-[80%] md:h-[65%] max-h-[400px] mb-5'>
+        <img
+          src={STORE_MOCK_DATA[STORE_PIC]}
+          alt={STORE_MOCK_DATA[STORE_NAME]}
+          className='object-cover w-full h-full rounded-lg'
+        />
+        <span className='text-text-light absolute top-2 right-2 text-2xl cursor-pointer '>
+          <IoCloseOutline />
+        </span>
+      </p>
+
+      <div className='flexCenter !justify-between  mb-[10px]'>
+        <h4 className='font-bold text-2xl sm:text-3xl text-text-light'>{STORE_MOCK_DATA[STORE_NAME]}</h4>
+        <span className='text-2xl cursor-pointer' onClick={addToBookmark}>
+          {isBookMarked ? <FaBookmark className='text-text-light' /> : <FaRegBookmark className='text-text-light' />}
+        </span>
+      </div>
+
+      <dl className='flex flex-wrap mb-[20px] text-text-light'>
+        {DETAIL_LIST.map((list) => (
+          <React.Fragment key={list.key}>
+            <dt className='w-[30%] sm:w-[20%] m-w-[150px] mb-1'>{list.title}</dt>
+            <dd className='w-[70%] sm:w-[80%]'>{STORE_MOCK_DATA[list.key] ?? list?.default}</dd>
+          </React.Fragment>
+        ))}
+      </dl>
+      <button className='w-full bg-white text-text-primary text-center py-1 rounded-lg'>
+        <FaYoutube className='text-4xl w-full' />
+      </button>
+    </section>
+  );
+}

--- a/src/components/modal/detail-modal.jsx
+++ b/src/components/modal/detail-modal.jsx
@@ -5,6 +5,8 @@ import { FaRegBookmark } from 'react-icons/fa6';
 import { FaBookmark } from 'react-icons/fa';
 import { useState } from 'react';
 import { STORE_CONSTANT } from '@/constants/store-constant';
+import { openAlert } from '@/lib/utils/openAlert';
+import { ALERT_TYPE } from '@/constants/alert-constant';
 const STORE_MOCK_DATA = {
   name: '양복점',
   category_name: '음식점',
@@ -14,7 +16,7 @@ const STORE_MOCK_DATA = {
   img_url:
     'https://ugc-images.catchtable.co.kr/catchtable/shopinfo/s2ITBk3Dv9LVsluH7e0DjIw/3619ed3090ef45d0a7e3f3c93e8489db',
 }; //TODO: supabase 데이터 완성되면 지울 예정
-
+const { INFO } = ALERT_TYPE;
 const { STORE_NAME, STORE_ADDRESS, STORE_CONTACT, STORE_PIC, BUSINESS_HOUR, CATEGORY } = STORE_CONSTANT;
 
 const DETAIL_LIST = [
@@ -46,8 +48,7 @@ export default function DetailModal() {
 
   const addToBookmark = () => {
     setIsBookMarked(!isBookMarked);
-    alert(`북마크${isBookMarked ? '에서 삭제' : '에 추가'}되었습니다.`);
-    //TODO: alert 추후에 sweetAlert를 쓰든 바꾸기
+    openAlert({ type: INFO, text: `북마크${isBookMarked ? '에서 삭제' : '에 추가'}되었습니다.` });
     //TODO: user의 bookmark 상태 바꾸기 (->post api연결)
   };
 

--- a/src/constants/alert-constant.js
+++ b/src/constants/alert-constant.js
@@ -1,0 +1,6 @@
+export const ALERT_TYPE = Object.freeze({
+  SUCCESS: 'success',
+  ERROR: 'error',
+  INFO: 'info',
+  WARNING: 'warning',
+});

--- a/src/constants/store-constant.js
+++ b/src/constants/store-constant.js
@@ -1,0 +1,8 @@
+export const STORE_CONSTANT = {
+  STORE_NAME: 'name',
+  STORE_ADDRESS: 'address_road_name',
+  STORE_CONTACT: 'contact_number',
+  CATEGORY: 'category_name',
+  STORE_PIC: 'img_url',
+  BUSINESS_HOUR: 'open_hours',
+}; //@TODO: 현재 기준 supabase의 data table을 기준으로 가져온 key입니다.

--- a/src/lib/utils/openAlert.js
+++ b/src/lib/utils/openAlert.js
@@ -1,0 +1,48 @@
+import { ALERT_TYPE } from '@/constants/alert-constant';
+import Swal from 'sweetalert2';
+
+const { ERROR, SUCCESS, INFO, WARNING } = ALERT_TYPE;
+export const openAlert = ({ type, text = '', buttonText = '확인' }) => {
+  if (!Object.values(ALERT_TYPE).includes(type)) {
+    console.error('invalid Alert Type');
+    return;
+  }
+
+  const alertType = {
+    [ERROR]: {
+      title: 'Error!',
+      text: text || '에러가 발생했습니다.',
+      icon: 'error',
+      confirmButtonText: buttonText || '확인',
+      confirmButtonColor: 'rgb(236 69 69)',
+    },
+    [SUCCESS]: {
+      title: 'Success!',
+      text: text || '완료되었습니다.',
+      icon: 'success',
+      confirmButtonText: buttonText || '확인',
+      confirmButtonColor: '#75d440',
+    },
+    [INFO]: {
+      title: 'Info',
+      text: text || '다시 확인해 주세요.',
+      icon: 'info',
+      confirmButtonText: buttonText || '확인',
+      confirmButtonColor: '#3FC3EE',
+    },
+    [WARNING]: {
+      title: 'Warning',
+      text: text || '적용하시겠습니까?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#75d440',
+      cancelButtonColor: 'rgb(236 69 69)',
+      confirmButtonText: buttonText || '적용',
+      cancelButtonText: '취소',
+      reverseButtons: true,
+    },
+  };
+
+  const alert = alertType[type];
+  return Swal.fire(alert);
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.jsx';
+import App from '@/App.jsx';
 import './style/global.css';
 
 createRoot(document.getElementById('root')).render(

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -9,3 +9,7 @@ body {
 .flexCenter {
   @apply flex items-center justify-center;
 }
+
+.modal {
+  @apply bg-[rgb(243,240,240)] w-[40%] max-w-[650px] min-w-[300px] min-h-[50dvh] max-h-[85dvh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-8 py-10 rounded-lg shadow-xl border border-slate-200;
+}

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -11,5 +11,5 @@ body {
 }
 
 .modal {
-  @apply bg-[rgb(243,240,240)] w-[40%] max-w-[650px] min-w-[300px] min-h-[50dvh] max-h-[85dvh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-8 py-10 rounded-lg shadow-xl border border-slate-200;
+  @apply bg-[rgb(246,245,245)] w-[40%] max-w-[650px] min-w-[300px] min-h-[50dvh] max-h-[85dvh] overflow-auto absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 px-8 py-10 rounded-lg shadow-xl border border-slate-200;
 }


### PR DESCRIPTION
## 💡 관련이슈
> #10 

## 🍀 작업 요약
1. Header 고정
2. 리스트에서 특정 상점 클릭 시 해당 상점에 대한 디테일 모달 레이아웃 작업
3. alert utils 생성

## 💬 리뷰 요구 사항
> [React-icons 라이브러리](https://react-icons.github.io/react-icons/)와 [sweetAlert2](https://sweetalert2.github.io/)를 설치했습니다.
처음에 pnpm install 한 번 받아주세요!
로컬에서 직접 모달을 보고싶다면 ? -> DetailModal  import 하셔서 확인해 보시면 됩니다!

![스크린샷 2025-02-27 오후 11 12 51](https://github.com/user-attachments/assets/7d239b7e-9119-4986-af89-72b9cf091c14)
추후에 제우님 메인 화면 작업 끝나시면 메인 화면에서 해당 모달 불러올 수 있도록
위에 첨부드린 사진처럼 코드 추가할 예정입니다~


## 특이사항

1.UI 구현은 해야하는데 데이터가 없어서, 우선 MOCK_DATA 만들어서 넣어놨습니다.
일단 일차적으로 UI에 대한 코드 리뷰 먼저 요청드립니다.

리뷰가 완료되면 dev에 merge하지 않고 다른 브랜치 따서 그 브랜치에 merge하겠습니다.
 ( dev에 merge 시 추후 api연결 후 충돌 예상 -> 새로 딴 다른 브랜치에서  api연결 작업 진행  )

2. sweetAlert는 utils에 openAlert라는 함수로 공통으로 뺐습니다.
제가 생각했을 땐, 성공/에러/안내/경고 정도면 충분할 거 같아서 우선 4가지의 타입만 작업해놨는데
더 필요한 타입 있으시면 추가해서 사용해 주시면 됩니다.
사용 예시는 다음과 같습니다.
`import { ALERT_TYPE } from '@/constants/alert-constant';`
`const { SUCCESS } =ALERT_TYPE; `
 `openAlert({ type: SUCCESS, text:"닉네임이 변경되었습니다.' });`

type은 상수로 정의해두었으니 거기서 꺼내쓰시면 됩니다. ( src/constants/alert-constant)
text는 alert에 보여질 문구를 의미합니다.
buttonText는 default로 '확인'으로 넣어놨습니다.
따라서 생략해도 무방하나 다른 문구를 넣고 싶다면 buttonText도 추가해 주세요!

## 💛 미리보기
> 
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/35acf33c-5bde-4986-a1b8-1c900c5b9426" />
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/65bc8b99-8330-4464-910d-b9ab522b9767" />



------------------------

의도치 않게 pr이 길어졌는데, 최최최종본입니다.^_^... 
디자인에 대한 비난은 모두 수용하겠습니다!
