### PR TITLE
Feature/#19 zustand 설정 작업 (회원정보와 로그인 여부)

### DIFF
--- a/src/store/zustand/authStore.js
+++ b/src/store/zustand/authStore.js
@@ -1,0 +1,36 @@
+//로그인 한 유저의 정보와 로그인 여부등을 localStorage에 저장하여 사용합니다.
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// 초기 상태 설정
+const initialState = {
+  isAuthenticated: false,
+  token: null,
+  userData: {
+    userId: '',
+    nickname: '',
+  },
+};
+
+const useAuthStore = create(
+  persist(
+    (set) => ({
+      ...initialState,
+      // 로그인 시 상태 업데이트
+      login: (token, userId, nickname) => {
+        set({ isAuthenticated: true, token, userData: { userId, nickname } });
+      },
+
+      // 로그아웃 시 상태 초기화
+      logout: () => {
+        set(initialState);
+      },
+    }),
+    {
+      name: 'auth-storage',
+      getStorage: () => localStorage,
+    }
+  )
+);
+
+export default useAuthStore;


### PR DESCRIPTION
## 💡 관련이슈
> #19

## 🍀 작업 요약
> zustand를 통해 현재 로그인 여부와 로그인한 유저의 간략한 정보를 로컬 스토리지에 저장하여 전역에서 사용합니다.

## 💬 리뷰 요구 사항
> 현재 수파베이스는 회원가입 성공시에 바로 로그인 상태를 반환하기 때문에 회원가입 함수내부에도 login함수가 포함되어야 할것 같습니다.

## 💛 미리보기
> ![image](https://github.com/user-attachments/assets/5b4556ab-f9d1-4037-bced-5bcc39ba385a)